### PR TITLE
Fix mint.json syntax error

### DIFF
--- a/wiki/mint.json
+++ b/wiki/mint.json
@@ -35,12 +35,10 @@
       "url": "https://www.canda.blog/"
     }
   ],
-  "topbarCtaButton": [
-    {
-      "name": "뉴스레터 구독하기",
-      "url": "https://www.canda.blog/#/portal/signup"
-    }
-  ],
+  "topbarCtaButton": {
+    "name": "뉴스레터 구독하기",
+    "url": "https://www.canda.blog/#/portal/signup"
+  },
   "topAnchor": {
     "name": "craft + alchemy wiki"
   },


### PR DESCRIPTION
# Summary

`topbarCtaButton` needs to be an object type


```
"topbarCtaButton": {
    "name": "뉴스레터 구독하기",
    "url": "https://www.canda.blog/#/portal/signup"
 }
```